### PR TITLE
Include title in scan result

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ JSON for detailed list of vulnerabilities:
         "packageName": "coreutils",
         "version": "8.30-3",
         "target": "radixdev.azurecr.io/radix-job-demo-api:cz413 (debian 10.10)",
+        "title": "coreutils: Non-privileged session can escape to the parent session in chroot",
         "description": "chroot in GNU coreutils...",
         "severity": "LOW",
         "publishedDate": "2017-02-07T15:59:00Z",

--- a/scan_image.sh
+++ b/scan_image.sh
@@ -34,7 +34,7 @@ mkdir /home/image-scanner/scan
 
 # TRIVY_NEW_JSON_SCHEMA: https://github.com/aquasecurity/trivy/discussions/1050
 TRIVY_NEW_JSON_SCHEMA=true trivy -q i -f json --timeout 20m  ${IMAGE_PATH} |
-  jq '[.Results[] | .Target as $target | .Vulnerabilities | .[]? | {packageName: .PkgName, version: .InstalledVersion, target: $target, description: .Description, severity: .Severity, publishedDate: .PublishedDate, cwe: .CweIDs, cve: [.VulnerabilityID], cvss: .CVSS["nvd"].V3Score, references: .References}]' \
+  jq '[.Results[] | .Target as $target | .Vulnerabilities | .[]? | {packageName: .PkgName, version: .InstalledVersion, target: $target, title: .Title, description: .Description, severity: .Severity, publishedDate: .PublishedDate, cwe: .CweIDs, cve: [.VulnerabilityID], cvss: .CVSS["nvd"].V3Score, references: .References}]' \
   > /home/image-scanner/scan/vulnerabilities.json || exit
 
 jq 'group_by(.severity | ascii_downcase) | [.[] | {severity: .[0].severity | ascii_downcase, count: length}] | [.[] | {(.severity):.count}] | add | if . == null then {} else . end' /home/image-scanner/scan/vulnerabilities.json \


### PR DESCRIPTION
Added Title from scan results to the scan output. Title is a short description of the vulnerability and can be used in the header of the vulnerability list in web-console.

Title and Description:
"title": "tar: Memory leak in read_header() in list.c",
"description": "A flaw was found in the src/list.c of tar 1.33 and earlier. This flaw allows an attacker who can submit a crafted input file to tar to cause uncontrolled consumption of memory. The highest threat from this vulnerability is to system availability."